### PR TITLE
Remove trailing ^M from numbers to get rid of warning

### DIFF
--- a/kerbalscience.php
+++ b/kerbalscience.php
@@ -222,7 +222,7 @@ while ($l = fgets($f))
 	// science multiplier
 	if (preg_match("@ScienceGainMultiplier = (.*)@",$l,$matches))
 	{
-		$sciencemultiplier = $matches[1];
+		$sciencemultiplier = trim($matches[1]);
 	}
 	
 	if (preg_match("@^\\t\\tScience\b@",$l))


### PR DESCRIPTION
This is an issue if you are using a modern php and unix